### PR TITLE
Update GitHub Actions workflow to trigger on master branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - master
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
- Changed the branch trigger in `publish.yml` from `main` to `master`, aligning with the current branch naming convention for releases.